### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Please note that importing entity collections requires re-indexing documents tha
 
 Custom crawlers are useful to directly import large amounts of data into the system. This can make sense for custom scrapers or crawlers where the indirection of using a metafolder is not desirable.
 
-Crawlers are Python classes and exposed via the ``entry_point`` of a Python package. To develop a custom crawler, start by setting up a separate Python package from ``aleph`` with it's own ``setup.py`` ([learn more](https://python-packaging.readthedocs.org/en/latest/)).
+Crawlers are Python classes and exposed via the ``entry_point`` of a Python package. To develop a custom crawler, start by setting up a separate Python package from ``aleph`` with it's own ``setup.py`` ([learn more](https://python-packaging.readthedocs.io/en/latest/)).
 
 A basic crawler will extend the relevant ``Crawler`` class from ``aleph`` and implement it's ``crawl()`` method:
 

--- a/aleph/ingest/tesseract.py
+++ b/aleph/ingest/tesseract.py
@@ -13,8 +13,8 @@ from aleph.model import Cache
 from aleph.ingest.ingestor import IngestorException
 from aleph.metadata.languages import get_iso3
 
-# https://tesserwrap.readthedocs.org/en/latest/#
-# https://pillow.readthedocs.org/en/3.0.x/reference/Image.html
+# https://tesserwrap.readthedocs.io/en/latest/#
+# https://pillow.readthedocs.io/en/3.0.x/reference/Image.html
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.