### PR TITLE
Make flask app context associate with new celery workers

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -22,7 +22,6 @@ log = logging.getLogger(__name__)
 db = SQLAlchemy()
 migrate = Migrate()
 mail = Mail()
-celery = Celery('aleph')
 assets = Environment()
 oauth = OAuth()
 oauth_provider = oauth.remote_app('provider', app_key='OAUTH')
@@ -35,7 +34,7 @@ USER_QUEUE = 'user'
 USER_ROUTING_KEY = 'user.process'
 WORKER_QUEUE = 'worker'
 WORKER_ROUTING_KEY = 'worker.process'
-
+CELERYD_MAX_TASKS_PER_CHILD = int(os.environ.get('CELERYD_MAX_TASKS_PER_CHILD', '10'))
 
 def create_app(config={}):
     app = Flask('aleph')
@@ -64,14 +63,12 @@ def create_app(config={}):
 
     app.config['CELERY_DEFAULT_QUEUE'] = WORKER_QUEUE
     app.config['CELERY_DEFAULT_ROUTING_KEY'] = WORKER_ROUTING_KEY
+    app.config['CELERYD_MAX_TASKS_PER_CHILD'] = CELERYD_MAX_TASKS_PER_CHILD
+
     app.config['CELERY_QUEUES'] = (
         Queue(WORKER_QUEUE, routing_key=WORKER_ROUTING_KEY),
         Queue(USER_QUEUE, routing_key=USER_ROUTING_KEY),
     )
-    celery.conf.update(app.config)
-    celery.conf.update({
-        'BROKER_URL': app.config['CELERY_BROKER_URL']
-    })
 
     migrate.init_app(app, db, directory=app.config.get('ALEMBIC_DIR'))
     oauth.init_app(app)
@@ -85,6 +82,24 @@ def create_app(config={}):
         plugin(app=app)
 
     return app
+
+
+def make_celery(flask_app):
+    celery = Celery('aleph', broker=flask_app.config['CELERY_BROKER_URL'])
+    celery.conf.update(flask_app.config)
+    celery.conf.update({
+        'BROKER_URL': flask_app.config['CELERY_BROKER_URL']
+    })
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with flask_app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+    celery.Task = ContextTask
+    return celery
 
 
 @migrate.configure
@@ -164,3 +179,5 @@ def url_for(*a, **kw):
         return flask_url_for(*a, **kw)
     except RuntimeError:
         return None
+
+celery = make_celery(create_app())

--- a/aleph/queue.py
+++ b/aleph/queue.py
@@ -1,4 +1,4 @@
-from aleph.core import create_app, celery as app  # noqa
+from aleph.core import create_app, make_celery  # noqa
 
 from aleph.ingest import ingest_url, ingest  # noqa
 from aleph.analyze import analyze_document_id  # noqa
@@ -9,4 +9,4 @@ from aleph.crawlers import execute_crawler  # noqa
 from aleph.events import save_event  # noqa
 
 flask_app = create_app()
-flask_app.app_context().push()
+app = make_celery(flask_app)


### PR DESCRIPTION
_NB:_ This instantiates a celery app in aleph.core as well as in aleph.queue - not sure of a nice way to call `with app.app_context()` the way they propose without calling it twice. Factoring it out of core would mean calling it in each client module? I'm just not seeing a nice way to deal with the worker and the web/manage.py setups so happy for proposals

This is working very nicely for me - it seems I can cycle my workers safely now, keeping RAM usage sane, while the new workers seem to use the flask app context correctly now and don't throw the runtime error.

Was getting 'application not registered on db instance and no application bound to current context'
when celery workers were restarted because of CELERYD_MAX_TASKS_PER_CHILD
or when killed by the kernel to free memory. CELERYD_MAX_TASKS_PER_CHILD
is needed to keep memory use under control
http://chase-seibert.github.io/blog/2013/08/03/diagnosing-memory-leaks-python.html

This sets a conservative default of CELERYD_MAX_TASKS_PER_CHILD=10
and makes sure a new app context is given to a new worker. You can configure this from the command line. I didn't route it through docker_options because I'm lazy and tired from running out of RAM all day
