### PR TITLE
Indicate signing in will allow you to set an alert

### DIFF
--- a/aleph/assets.py
+++ b/aleph/assets.py
@@ -60,6 +60,8 @@ def compile_assets(app):
     js_path = os.path.join(app.static_folder, 'js')
     for (root, dirs, files) in os.walk(js_path):
         for file_name in sorted(files):
+            if file_name.startswith('.'):
+                continue
             file_path = os.path.relpath(os.path.join(root, file_name),
                                         app.static_folder)
             js_files.append(file_path)

--- a/aleph/static/templates/documents/search.html
+++ b/aleph/static/templates/documents/search.html
@@ -14,7 +14,12 @@
               Disable alert
             </span>
             <span ng-if="!hasAlert()">
-              Set alert
+              <span ng-if="canCreateAlert()">
+                Set an alert
+              </span>
+              <span ng-if="!canCreateAlert()">
+                Sign in to set an alert
+              </span>
             </span>
           </button>
         </div>

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -25,6 +25,8 @@ def angular_templates():
             tmpl_dir = os.path.join(template_dir, tmpl_set)
             for (root, dirs, files) in os.walk(tmpl_dir):
                 for file_name in files:
+                    if file_name.startswith('.'):
+                        continue
                     file_path = os.path.join(root, file_name)
                     with open(file_path, 'rb') as fh:
                         file_name = file_path[len(template_dir) + 1:]


### PR DESCRIPTION
Our users thought this functionality wasn't yet enabled.

This patch also prevents .swp files from being sucked in as assets.