### PR TITLE
Support for multiple OAUTH providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
   global:
     - ALEPH_TEST_SETTINGS=$TRAVIS_BUILD_DIR/test_settings.py
     - WKHTMLTOPDF_BIN=$TRAVIS_BUILD_DIR/wkhtmltox/bin/wkhtmltopdf
+    - OAUTH_KEY=fake
+    - OAUTH_SECRET=fake
 before_install:
   - sudo apt-get -qq update
   - sudo apt-get install -y tesseract-ocr-eng readpst

--- a/aleph/core.py
+++ b/aleph/core.py
@@ -7,7 +7,6 @@ from flask import url_for as flask_url_for
 from flask_sqlalchemy import SQLAlchemy
 from flask_assets import Environment
 from flask_migrate import Migrate
-from flask_oauthlib.client import OAuth
 from flask_mail import Mail
 from kombu import Queue
 from celery import Celery
@@ -16,6 +15,7 @@ from elasticsearch import Elasticsearch
 
 from aleph import default_settings, archive
 from aleph.ext import get_init
+from aleph.oauth import configure_oauth
 
 log = logging.getLogger(__name__)
 
@@ -24,8 +24,6 @@ migrate = Migrate()
 mail = Mail()
 celery = Celery('aleph')
 assets = Environment()
-oauth = OAuth()
-oauth_provider = oauth.remote_app('provider', app_key='OAUTH')
 
 # these two queues are used so that background processing tasks
 # spawned by the user can be handled more quickly through a
@@ -74,7 +72,7 @@ def create_app(config={}):
     })
 
     migrate.init_app(app, db, directory=app.config.get('ALEMBIC_DIR'))
-    oauth.init_app(app)
+    configure_oauth(app)
     mail.init_app(app)
     db.init_app(app)
     assets.init_app(app)

--- a/aleph/default_settings.py
+++ b/aleph/default_settings.py
@@ -145,7 +145,8 @@ CELERYBEAT_SCHEDULE = {
     },
 }
 
-OAUTH = {
+OAUTH = [{
+    'name': 'google',
     'consumer_key': env.get('OAUTH_KEY'),
     'consumer_secret': env.get('OAUTH_SECRET'),
     'request_token_params': {
@@ -156,4 +157,4 @@ OAUTH = {
     'access_token_method': 'POST',
     'access_token_url': 'https://accounts.google.com/o/oauth2/token',
     'authorize_url': 'https://accounts.google.com/o/oauth2/auth',
-}
+}]

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -1,0 +1,34 @@
+from flask_oauthlib.client import OAuth
+from flask import session
+
+oauth = OAuth()
+
+
+def get_oauth_token():
+    if 'oauth' in session:
+        sig = session.get('oauth')
+        return (sig.get('access_token'), '')
+
+
+def setup_providers(app):
+    providers = app.config.get('OAUTH', [])
+    if isinstance(providers, dict):
+        # support for legacy single provider
+        providers = [providers]
+
+    for provider in providers:
+        name = provider.pop('name')
+        # legacy provider
+        if name == 'provider':
+            name = 'google'
+        label = provider.pop('label', name.capitalize())
+
+        provider = oauth.remote_app(name, **provider)
+        provider.label = label
+        provider.tokengetter(get_oauth_token)
+
+
+def configure_oauth(app):
+    setup_providers(app)
+    oauth.init_app(app)
+    return oauth

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -22,10 +22,10 @@ def setup_providers(app):
 
     for provider in providers:
         # OAUTH providers from the config MUST have a name entry
-        name = provider.pop('name')
+        name = provider.get('name')
         label = provider.pop('label', name.capitalize())
 
-        provider = oauth.remote_app(name, **provider)
+        provider = oauth.remote_app(**provider)
         provider.label = label
         provider.tokengetter(get_oauth_token)
 

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -16,14 +16,14 @@ def get_oauth_token():
 def setup_providers(app):
     providers = app.config.get('OAUTH', [])
     if isinstance(providers, dict):
-        # support for legacy single provider
+        # support for legacy single google provider
+        if 'name' not in providers:
+            providers['name'] = 'google'
         providers = [providers]
 
     for provider in providers:
+        # OAUTH providers from the config MUST have a name entry
         name = provider.pop('name')
-        # legacy provider
-        if name == 'provider':
-            name = 'google'
         label = provider.pop('label', name.capitalize())
 
         provider = oauth.remote_app(name, **provider)

--- a/aleph/oauth.py
+++ b/aleph/oauth.py
@@ -2,7 +2,6 @@ from flask_oauthlib.client import OAuth
 from flask import session
 
 from aleph import signals
-from aleph.model import Role
 
 oauth = OAuth()
 
@@ -39,6 +38,8 @@ def configure_oauth(app):
 
 @signals.handle_oauth_session.connect
 def handle_google_oauth(sender, provider=None, session=None):
+    from aleph.model import Role
+
     # If you wish to use another OAuth provider with your installation of
     # aleph, you can create a Python extension package and include a
     # custom oauth handler like this, which will create roles and state
@@ -55,6 +56,8 @@ def handle_google_oauth(sender, provider=None, session=None):
 
 @signals.handle_oauth_session.connect
 def handle_facebook_oauth(sender, provider=None, session=None):
+    from aleph.model import Role
+
     if 'facebook.com' not in provider.base_url:
         return
     me = provider.get('me?fields=id,name,email')

--- a/aleph/static/js/controllers/AppCtrl.js
+++ b/aleph/static/js/controllers/AppCtrl.js
@@ -70,4 +70,16 @@ aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll
     });
   };
 
+  $scope.showLogin = function($event) {
+    $event.stopPropagation();
+    var instance = $uibModal.open({
+      templateUrl: 'templates/login.html',
+      controller: 'SessionCtrl',
+      backdrop: true,
+      size: 'md',
+      resolve: {
+        metadata: loadMetadata
+      }
+    });
+  };
 }]);

--- a/aleph/static/js/controllers/AppCtrl.js
+++ b/aleph/static/js/controllers/AppCtrl.js
@@ -41,8 +41,20 @@ aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll
   };
 
   $rootScope.triggerLogin = function() {
-    var url = $httpParamSerializer({next: $location.url()});
-    document.location.href = '/api/1/sessions/login?' + url;
+    if ($scope.session.providers.length == 1) {
+      var url = $httpParamSerializer({next: $location.url()});
+      document.location.href = $scope.session.providers[0].login + '?' + url;
+    } else {
+      $uibModal.open({
+        templateUrl: 'templates/login.html',
+        controller: 'SessionCtrl',
+        backdrop: true,
+        size: 'md',
+        resolve: {
+          metadata: loadMetadata
+        }
+      });
+    }
   };  
 
   $scope.editProfile = function($event) {
@@ -66,19 +78,6 @@ aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll
       size: 'md',
       resolve: {
         alerts: Alert.index()
-      }
-    });
-  };
-
-  $scope.showLogin = function($event) {
-    $event.stopPropagation();
-    var instance = $uibModal.open({
-      templateUrl: 'templates/login.html',
-      controller: 'SessionCtrl',
-      backdrop: true,
-      size: 'md',
-      resolve: {
-        metadata: loadMetadata
       }
     });
   };

--- a/aleph/static/js/controllers/SessionCtrl.js
+++ b/aleph/static/js/controllers/SessionCtrl.js
@@ -1,0 +1,5 @@
+aleph.controller('SessionCtrl', ['$scope', '$uibModalInstance', 'metadata',
+    function($scope, $uibModalInstance, metadata) {
+  $scope.providers = metadata.session.providers;
+
+}]);

--- a/aleph/static/js/controllers/SessionCtrl.js
+++ b/aleph/static/js/controllers/SessionCtrl.js
@@ -1,5 +1,5 @@
-aleph.controller('SessionCtrl', ['$scope', '$uibModalInstance', 'metadata',
-    function($scope, $uibModalInstance, metadata) {
+aleph.controller('SessionCtrl', ['$scope', '$location', '$uibModalInstance', '$httpParamSerializer', 'metadata',
+    function($scope, $location, $uibModalInstance, $httpParamSerializer, metadata) {
   $scope.providers = metadata.session.providers;
-
+  $scope.next_url = $httpParamSerializer({next: $location.url()});
 }]);

--- a/aleph/static/style/_session.scss
+++ b/aleph/static/style/_session.scss
@@ -1,0 +1,32 @@
+.login-facebook {
+  background-color: #3b5998;
+  color: white;
+
+  &::before {
+    font-family: FontAwesome;
+    margin-right: 9px;
+    content: "\f09a";
+  }
+}
+
+.login-google {
+  background-color: #5b76f7;
+  color: white;
+
+  &::before {
+    font-family: FontAwesome;
+    margin-right: 9px;
+    content: "\f1a0";
+  }
+}
+
+.login-twitter {
+  background-color: #00bced;
+  color: white;
+
+  &::before {
+    font-family: FontAwesome;
+    margin-right: 9px;
+    content: "\f099";
+  }
+}

--- a/aleph/static/style/aleph.scss
+++ b/aleph/static/style/aleph.scss
@@ -60,6 +60,7 @@ footer {
 @import "spinner";
 @import "entities";
 @import "collections";
+@import "session";
 
 .list-group-item.active {
     .badge {

--- a/aleph/static/templates/login.html
+++ b/aleph/static/templates/login.html
@@ -1,0 +1,18 @@
+<div class="modal-header">
+  <button type="button" class="close" ng-click="$dismiss()" aria-hidden="true">&times;</button>
+  <h4 class="modal-title">Sign in</h4>
+</div>
+
+<div class="modal-body">
+  <div class="row">
+    <div class="col-sm-6 col-sm-offset-3">
+      <p ng-repeat="provider in providers">
+        <a href="{{ provider.login }}" class="btn btn-default btn-block login-{{ provider.name }}" target="_self">Sign in with {{ provider.label }}</a>
+      </p>
+    </div>
+  </div>
+</div>
+
+<div class="modal-footer">
+  <button type="button" class="btn btn-default" ng-click="$dismiss()">Cancel</button>
+</div>

--- a/aleph/static/templates/login.html
+++ b/aleph/static/templates/login.html
@@ -7,7 +7,7 @@
   <div class="row">
     <div class="col-sm-6 col-sm-offset-3">
       <p ng-repeat="provider in providers">
-        <a href="{{ provider.login }}" class="btn btn-default btn-block login-{{ provider.name }}" target="_self">Sign in with {{ provider.label }}</a>
+        <a href="{{ provider.login }}?{{ next_url }}" class="btn btn-default btn-block login-{{ provider.name }}" target="_self">Sign in with {{ provider.label }}</a>
       </p>
     </div>
   </div>

--- a/aleph/tests/util.py
+++ b/aleph/tests/util.py
@@ -10,6 +10,7 @@ from aleph.analyze import analyze_document
 from aleph.logic import reindex_entities
 from aleph.core import db, create_app
 from aleph.views import mount_app_blueprints
+from aleph.oauth import oauth
 
 FIXTURES = os.path.join(os.path.dirname(__file__), 'fixtures')
 
@@ -18,6 +19,7 @@ class TestCase(FlaskTestCase):
 
     def create_app(self):
         self.temp_dir = mkdtemp()
+        oauth.remote_apps = {}
         app = create_app({
             'DEBUG': True,
             'TESTING': True,

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -97,34 +97,6 @@ def logout():
     return redirect('/')
 
 
-@signals.handle_oauth_session.connect
-def handle_google_oauth(sender, provider=None, session=None):
-    # If you wish to use another OAuth provider with your installation of
-    # aleph, you can create a Python extension package and include a
-    # custom oauth handler like this, which will create roles and state
-    # for your session.
-    if 'googleapis.com' not in provider.base_url:
-        return
-    me = provider.get('userinfo')
-    user_id = 'google:%s' % me.data.get('id')
-    role = Role.load_or_create(user_id, Role.USER, me.data.get('name'),
-                               email=me.data.get('email'))
-    session['roles'].append(role.id)
-    session['user'] = role.id
-
-
-@signals.handle_oauth_session.connect
-def handle_facebook_oauth(sender, provider=None, session=None):
-    if 'facebook.com' not in provider.base_url:
-        return
-    me = provider.get('me?fields=id,name,email')
-    user_id = 'facebook:%s' % me.data.get('id')
-    role = Role.load_or_create(user_id, Role.USER, me.data.get('name'),
-                               email=me.data.get('email'))
-    session['roles'].append(role.id)
-    session['user'] = role.id
-
-
 @blueprint.route('/api/1/sessions/callback/<string:provider>')
 def callback(provider):
     oauth_provider = oauth.remote_apps.get(provider)

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -1,11 +1,12 @@
 import logging
-from flask import session, Blueprint, redirect, request
+from flask import session, Blueprint, redirect, request, abort
 from flask_oauthlib.client import OAuthException
 from apikit import jsonify
 from werkzeug.exceptions import Unauthorized
 
 from aleph import authz, signals
-from aleph.core import db, url_for, oauth_provider
+from aleph.core import db, url_for
+from aleph.oauth import oauth
 from aleph.model import Role
 from aleph.events import log_event
 from aleph.views.cache import enable_cache
@@ -14,13 +15,6 @@ from aleph.views.util import is_safe_url
 
 log = logging.getLogger(__name__)
 blueprint = Blueprint('sessions_api', __name__)
-
-
-@oauth_provider.tokengetter
-def get_oauth_token():
-    if 'oauth' in session:
-        sig = session.get('oauth')
-        return (sig.get('access_token'), '')
 
 
 @blueprint.before_app_request
@@ -50,6 +44,14 @@ def load_role():
 @blueprint.route('/api/1/sessions')
 def status():
     enable_cache(vary_user=True)
+
+    providers = sorted(oauth.remote_apps.values(), key=lambda p: p.label)
+    providers = [{
+        'name': p.name,
+        'label': p.label,
+        'login': url_for('sessions_api.login', provider=p.name),
+    } for p in providers]
+
     return jsonify({
         'logged_in': authz.logged_in(),
         'api_key': request.auth_role.api_key if authz.logged_in() else None,
@@ -61,12 +63,23 @@ def status():
             'write': authz.collections(authz.WRITE)
         },
         'login': url_for('.login'),
-        'logout': url_for('.logout')
+        'logout': url_for('.logout'),
+        'providers': providers,
     })
 
 
 @blueprint.route('/api/1/sessions/login')
-def login():
+@blueprint.route('/api/1/sessions/login/<string:provider>')
+def login(provider=None):
+    if not provider:
+        # by default use the first provider if none is requested,
+        # which is a useful default if there's only one
+        provider = oauth.remote_apps.keys()[0]
+
+    oauth_provider = oauth.remote_apps.get(provider)
+    if not oauth_provider:
+        abort(404)
+
     log_event(request)
     next_url = '/'
     for target in request.args.get('next'), request.referrer:
@@ -75,7 +88,7 @@ def login():
         if is_safe_url(target):
             next_url = target
     session['next_url'] = next_url
-    return oauth_provider.authorize(callback=url_for('.callback'))
+    return oauth_provider.authorize(callback=url_for('.callback', provider=provider))
 
 
 @blueprint.route('/api/1/sessions/logout')
@@ -100,9 +113,26 @@ def handle_google_oauth(sender, provider=None, session=None):
     session['user'] = role.id
 
 
-@blueprint.route('/api/1/sessions/callback')
-def callback():
+@signals.handle_oauth_session.connect
+def handle_facebook_oauth(sender, provider=None, session=None):
+    if 'facebook.com' not in provider.base_url:
+        return
+    me = provider.get('me?fields=id,name,email')
+    user_id = 'facebook:%s' % me.data.get('id')
+    role = Role.load_or_create(user_id, Role.USER, me.data.get('name'),
+                               email=me.data.get('email'))
+    session['roles'].append(role.id)
+    session['user'] = role.id
+
+
+@blueprint.route('/api/1/sessions/callback/<string:provider>')
+def callback(provider):
+    oauth_provider = oauth.remote_apps.get(provider)
+    if not oauth_provider:
+        abort(404)
+
     next_url = session.pop('next_url', '/')
+
     resp = oauth_provider.authorized_response()
     if resp is None or isinstance(resp, OAuthException):
         log.warning("Failed OAuth: %r", resp)

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -49,7 +49,7 @@ def status():
     providers = [{
         'name': p.name,
         'label': p.label,
-        'login': url_for('sessions_api.login', provider=p.name),
+        'login': url_for('.login', provider=p.name),
     } for p in providers]
 
     return jsonify({
@@ -62,7 +62,6 @@ def status():
             'read': authz.collections(authz.READ),
             'write': authz.collections(authz.WRITE)
         },
-        'login': url_for('.login'),
         'logout': url_for('.logout'),
         'providers': providers,
     })

--- a/contrib/docker_settings.py
+++ b/contrib/docker_settings.py
@@ -41,7 +41,14 @@ ARCHIVE_AWS_SECRET = os.environ.get('AWS_SECRET_ACCESS_KEY')
 ARCHIVE_BUCKET = os.environ.get('ALEPH_ARCHIVE_BUCKET')
 ARCHIVE_PATH = os.environ.get('ALEPH_ARCHIVE_PATH')
 
-OAUTH = {
+# Configure your choice of OAUTH login providers, one
+# entry for each provider, providing the details as described in
+# https://flask-oauthlib.readthedocs.io/en/latest/client.html
+#
+# In addition, include a 'name' entry and an optional 'label' entry.
+OAUTH = [{
+    'name': 'google',
+    'label': 'Google',
     'consumer_key': os.environ.get('ALEPH_OAUTH_KEY'),
     'consumer_secret': os.environ.get('ALEPH_OAUTH_SECRET'),
     'request_token_params': {
@@ -52,7 +59,7 @@ OAUTH = {
     'access_token_method': 'POST',
     'access_token_url': 'https://accounts.google.com/o/oauth2/token',
     'authorize_url': 'https://accounts.google.com/o/oauth2/auth',
-}
+}]
 
 OCR_PDF_PAGES = os.environ.get('ALEPH_PDF_OCR_IMAGE_PAGES', 'true')
 OCR_PDF_PAGES = OCR_PDF_PAGES.strip().lower() == "true"


### PR DESCRIPTION
This updates the OAUTH support to handle multiple providers. The login endpoint changes to `/api/1/sessions/login/<provider>` and the callback URL changes similarly. There is built-in support for Facebook and Google, and it's very easy to add support for other providers.

NB: the callback URL entered into the Google Developer Console must be updated.

When the user clicks the login dialog they get a modal popup giving them a choice of login providers.

This doesn't yet include full support for Twitter, because I don't yet have a functioning Twitter OAUTH setup.

![sign-in](https://cloud.githubusercontent.com/assets/4178542/19249090/eca05aae-8f33-11e6-900d-09dd68f62b6d.png)