### PR TITLE
Credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ install:
 before_script:
   - sleep 10
   - psql -c "create database ${ALEPH_DATABASE_NAME}_test;" -U postgres
+  - psql -c "create extension pgcrypto;" -U postgres ${ALEPH_DATABASE_NAME}_test
   - elasticsearch --version
   - nosetests --version
   - psql --version

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ assets-dev: assets
 test:
 	PGPASSWORD=aleph psql -h postgres -U aleph -c 'drop database if exists aleph_test;'
 	PGPASSWORD=aleph psql -h postgres -U aleph -c 'create database aleph_test;'
+	PGPASSWORD=aleph psql -h postgres -U aleph aleph_test -c 'create extension pgcrypto;'
 	nosetests --with-coverage --cover-package=aleph --cover-erase
 
 base:

--- a/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
+++ b/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
@@ -65,8 +65,9 @@ def upgrade():
     creds_table = meta.tables['credential']
 
     credentials = []
+    roles_query = sa.select([role_table]).where(role_table.c.type == 'user')
 
-    for role in bind.execute(sa.select([role_table])).fetchall():
+    for role in bind.execute(roles_query).fetchall():
         credentials.append(
             dict(
                 id=make_textid(),

--- a/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
+++ b/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
@@ -1,0 +1,85 @@
+"""Added credentials.
+
+Revision ID: 2d230e6ce46d
+Revises: 294b8f9f9478
+Create Date: 2017-01-26 21:42:52.722454
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2d230e6ce46d'
+down_revision = '294b8f9f9478'
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import sessionmaker
+
+from aleph.core import db
+from aleph.model import Role, Credential
+from aleph.model.common import make_textid
+
+
+def upgrade():
+    op.create_table('credential',
+        sa.Column('id', sa.String(length=32), nullable=False),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.Column('used_at', sa.DateTime(), nullable=True),
+        sa.Column('secret', sa.LargeBinary(60)),
+        sa.Column('reset_token', sa.Unicode(32)),
+        sa.Column(
+            'foreign_id',
+            sa.Unicode(length=2048),
+            nullable=False,
+            unique=True
+        ),
+        sa.Column(
+            'source',
+            sa.Enum(*Credential.SOURCES, name='credential_source'),
+            nullable=False
+        ),
+
+        sa.Column('role_id', sa.Integer()),
+        sa.ForeignKeyConstraint(['role_id'], ['role.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+
+    op.create_index(
+        op.f('credential_reset_token'),
+        'credential',
+        ['reset_token'],
+        unique=True
+    )
+    op.create_index(
+        op.f('credential_role_id'),
+        'credential',
+        ['role_id'],
+        unique=False
+    )
+
+    bind = op.get_bind()
+    meta = sa.MetaData()
+    meta.bind = bind
+    meta.reflect()
+    role_table = meta.tables['role']
+    creds_table = meta.tables['credential']
+
+    credentials = []
+
+    for role in bind.execute(sa.select([role_table])).fetchall():
+        credentials.append(
+            dict(
+                id=make_textid(),
+                role_id=role.id,
+                foreign_id=role.foreign_id,
+                source=Credential.OAUTH,
+                created_at=role.created_at,
+            )
+        )
+
+    op.bulk_insert(creds_table, credentials)
+    op.drop_column('role', 'foreign_id')
+
+
+def downgrade():
+    pass

--- a/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
+++ b/aleph/migrate/versions/2d230e6ce46d_added_credentials.py
@@ -20,12 +20,14 @@ from aleph.model.common import make_textid
 
 
 def upgrade():
+    op.execute('create extension pgcrypto')
+
     op.create_table('credential',
         sa.Column('id', sa.String(length=32), nullable=False),
         sa.Column('created_at', sa.DateTime(), nullable=True),
         sa.Column('updated_at', sa.DateTime(), nullable=True),
         sa.Column('used_at', sa.DateTime(), nullable=True),
-        sa.Column('secret', sa.LargeBinary(60)),
+        sa.Column('secret', sa.Unicode(60)),
         sa.Column('reset_token', sa.Unicode(32)),
         sa.Column(
             'foreign_id',

--- a/aleph/model/__init__.py
+++ b/aleph/model/__init__.py
@@ -2,8 +2,8 @@ import logging
 import flask_migrate
 
 from aleph.core import db  # noqa
-from aleph.model.role import Role  # noqa
 from aleph.model.credential import Credential  # noqa
+from aleph.model.role import Role  # noqa
 from aleph.model.alert import Alert  # noqa
 from aleph.model.permission import Permission  # noqa
 from aleph.model.entity import Entity  # noqa

--- a/aleph/model/__init__.py
+++ b/aleph/model/__init__.py
@@ -3,6 +3,7 @@ import flask_migrate
 
 from aleph.core import db  # noqa
 from aleph.model.role import Role  # noqa
+from aleph.model.credential import Credential  # noqa
 from aleph.model.alert import Alert  # noqa
 from aleph.model.permission import Permission  # noqa
 from aleph.model.entity import Entity  # noqa

--- a/aleph/model/common.py
+++ b/aleph/model/common.py
@@ -67,7 +67,7 @@ class IdModel(object):
 
 
 class UuidModel(object):
-    id = db.Column(db.String(32), primary_key=True, default=make_textid(),
+    id = db.Column(db.String(32), primary_key=True, default=make_textid,
                    nullable=False, unique=False)
 
     def to_dict(self):

--- a/aleph/model/credential.py
+++ b/aleph/model/credential.py
@@ -33,4 +33,7 @@ class Credential(db.Model, UuidModel, DatedModel):
     used_at = db.Column(db.DateTime)
 
     #: Role relationship.
-    role_id = db.Column(db.Integer, db.ForeignKey('role.id'), index=True)
+    role_id = db.Column(
+        db.Integer, db.ForeignKey('role.id', ondelete='CASCADE'), index=True)
+    role = db.relationship(
+        'Role', backref=db.backref('credentials', lazy='dynamic'))

--- a/aleph/model/credential.py
+++ b/aleph/model/credential.py
@@ -1,0 +1,37 @@
+from aleph.core import db
+from aleph.model.common import UuidModel, DatedModel
+
+
+class Credential(UuidModel, DatedModel):
+    """A role can own multiple credentials and can authenticate by using any of
+    the credentials.
+
+    The concept behind this is to provide multiple authentication strategies
+    for a single role: from password-based authentication to OAuth or LDAP.
+    """
+
+    OAUTH = 'oauth'
+    PASSWORD = 'password'
+    LDAP = 'ldap'
+    SOURCES = [OAUTH, PASSWORD, LDAP]
+
+    __tablename__ = 'credential'
+
+    #: Indicates credential source, ex.: oauth, passoword, ldap...
+    source = db.Column(
+        db.Enum(*SOURCES, name='credential_source'),
+        nullable=False
+    )
+
+    #: Foreign identifier, migrated from the initial `role` table.
+    foreign_id = db.Column(db.Unicode(2048), nullable=False, unique=True)
+    #: Secret to _unlock_ the credential, aka password encrypted hash.
+    secret = db.Column(db.LargeBinary(60))
+    #: Token to allow resetting the secret.
+    reset_token = db.Column(db.Unicode(32), unique=True, index=True)
+    #: Last date/time when credential was used.
+    used_at = db.Column(db.DateTime)
+
+    #: Role relationship.
+    role_id = db.Column(db.Integer, db.ForeignKey('role.id'), index=True)
+    role = db.relationship('Role', backref=db.backref('credentials'))

--- a/aleph/model/credential.py
+++ b/aleph/model/credential.py
@@ -2,7 +2,7 @@ from aleph.core import db
 from aleph.model.common import UuidModel, DatedModel
 
 
-class Credential(UuidModel, DatedModel):
+class Credential(db.Model, UuidModel, DatedModel):
     """A role can own multiple credentials and can authenticate by using any of
     the credentials.
 
@@ -34,4 +34,3 @@ class Credential(UuidModel, DatedModel):
 
     #: Role relationship.
     role_id = db.Column(db.Integer, db.ForeignKey('role.id'), index=True)
-    role = db.relationship('Role', backref=db.backref('credentials'))

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -118,6 +118,22 @@ class Role(db.Model, IdModel, SoftDeleteModel):
             current_app._authz_roles[foreign_id] = role.id
         return current_app._authz_roles[foreign_id]
 
+    @classmethod
+    def authenticate_using_credential(cls, email, password):
+        """Autheticates an user based on the email and password.
+
+        :param str email: User email.
+        :param str password: User password.
+        :return: A matched role.
+        :rtype: :py:class:`Role`
+        """
+        return db.session.query(cls).join(Credential).filter(
+            cls.email == email,
+            Credential.secret != None,
+            ~Credential.source.in_(Credential.EXTERNAL_SOURCES),
+            db.func.crypt(password, Credential.secret) == Credential.secret
+        ).first()
+
     def load_or_create_credentials(self, foreign_id):
         """Returns role credentials based on the foreign identifier.
 

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -138,6 +138,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
             return
 
         credential.used_at = datetime.utcnow()
+        db.session.add(credential)
         db.session.commit()
 
         return credential.role

--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -1,10 +1,9 @@
 import logging
-from uuid import uuid4
 from flask import current_app
 
 from aleph.core import db, url_for, get_config
 from aleph.data.validate import validate
-from aleph.model.common import SoftDeleteModel, IdModel
+from aleph.model.common import SoftDeleteModel, IdModel, make_textid
 
 log = logging.getLogger(__name__)
 
@@ -77,7 +76,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
             role.is_admin = False
 
         if role.api_key is None:
-            role.api_key = uuid4().hex
+            role.api_key = make_textid()
 
         role.email = email
         if is_admin is not None:

--- a/aleph/tests/factories/models/__init__.py
+++ b/aleph/tests/factories/models/__init__.py
@@ -1,2 +1,4 @@
-from .collection import CollectionFactory
-from .entity import EntityFactory
+from .collection import CollectionFactory  # noqa
+from .entity import EntityFactory  # noqa
+from .role import RoleFactory  # noqa
+from .credential import CredentialFactory  #noqa

--- a/aleph/tests/factories/models/credential.py
+++ b/aleph/tests/factories/models/credential.py
@@ -1,0 +1,21 @@
+import factory
+
+from aleph.core import db
+from aleph.model import Credential
+
+from .role import RoleFactory
+
+
+class CredentialFactory(factory.alchemy.SQLAlchemyModelFactory):
+
+    class Meta:
+        model = Credential
+        sqlalchemy_session = db.session
+
+    reset_token = factory.Sequence(
+        lambda n: factory.Faker('uuid4').generate({}).replace('-', ''))
+
+    source = factory.Iterator(Credential.SOURCES)
+    foreign_id = factory.Faker('md5')
+    secret = factory.Faker('md5')
+    role = factory.SubFactory(RoleFactory)

--- a/aleph/tests/factories/models/role.py
+++ b/aleph/tests/factories/models/role.py
@@ -1,0 +1,16 @@
+import factory
+
+from aleph.core import db
+from aleph.model import Role
+
+
+class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
+
+    class Meta:
+        model = Role
+        sqlalchemy_session = db.session
+
+    type = Role.USER
+    name = factory.Faker('name')
+    email = factory.Faker('email')
+    api_key = factory.Faker('uuid4')

--- a/aleph/tests/test_credential_model.py
+++ b/aleph/tests/test_credential_model.py
@@ -1,0 +1,21 @@
+from aleph.core import db
+from aleph.model import Credential
+from aleph.tests.factories.models import CredentialFactory
+from aleph.tests.util import TestCase
+
+
+class CredentialModelTest(TestCase):
+
+    def setUp(self):
+        super(CredentialModelTest, self).setUp()
+
+        self.secret = 'secret'
+        self.cred = CredentialFactory.create(secret=self.secret)
+        self.role = self.cred.role
+
+        db.session.flush()
+
+    def test_attributes(self):
+        self.assertIn(self.cred, self.role.credentials)
+        self.assertIsNone(self.cred.used_at)
+        self.assertEqual(self.cred.secret.encode('utf-8'), self.secret)

--- a/aleph/tests/test_credential_model.py
+++ b/aleph/tests/test_credential_model.py
@@ -19,3 +19,13 @@ class CredentialModelTest(TestCase):
         self.assertIn(self.cred, self.role.credentials)
         self.assertIsNone(self.cred.used_at)
         self.assertEqual(self.cred.secret.encode('utf-8'), self.secret)
+
+    def test_update_secret(self):
+        prev_secret = self.cred.secret
+
+        self.assertIsNotNone(prev_secret)
+
+        new_secret = self.cred.update_secret(self.fake.password())
+
+        self.assertIsNotNone(new_secret)
+        self.assertNotEqual(prev_secret, new_secret)

--- a/aleph/tests/test_models.py
+++ b/aleph/tests/test_models.py
@@ -7,9 +7,6 @@ from aleph.tests.util import TestCase
 
 class EntityModelTest(TestCase):
 
-    def tearDown(self):
-        pass
-
     def setUp(self):
         super(EntityModelTest, self).setUp()
 

--- a/aleph/tests/test_role_model.py
+++ b/aleph/tests/test_role_model.py
@@ -1,0 +1,53 @@
+from aleph.core import db
+from aleph.model import Credential
+from aleph.tests.factories.models import RoleFactory, CredentialFactory
+from aleph.tests.util import TestCase
+
+
+class RoleModelTest(TestCase):
+
+    def setUp(self):
+        super(RoleModelTest, self).setUp()
+
+        self.role = RoleFactory.create()
+        db.session.commit()
+
+    def test_attributes(self):
+        self.assertEqual(self.role.credentials.count(), 0)
+
+        cred = CredentialFactory(role=self.role)
+        db.session.flush()
+
+        self.assertEqual(self.role.credentials.count(), 1)
+        self.assertIn(cred, self.role.credentials)
+
+    def test_load_or_create_credentials_new_foreign_id(self):
+        foreign_id = '{}:{}'.format(Credential.OAUTH, self.fake.md5())
+
+        cred = self.role.load_or_create_credentials(foreign_id)
+
+        self.assertIsInstance(cred, Credential)
+        self.assertEqual(cred.source, Credential.OAUTH)
+        self.assertEqual(cred.foreign_id, foreign_id)
+        self.assertIsNotNone(cred.used_at)
+
+    def test_load_or_create_credentials_password(self):
+        foreign_id = '{}:{}'.format(Credential.PASSWORD, self.fake.md5())
+
+        cred = self.role.load_or_create_credentials(foreign_id)
+
+        self.assertEqual(cred.source, Credential.PASSWORD)
+        self.assertEqual(
+            cred.foreign_id, '{}:{}'.format(Credential.PASSWORD, self.role.id))
+
+    def test_load_or_create_credentials_exists(self):
+        foreign_id = '{}:{}'.format(Credential.OAUTH, self.fake.md5())
+
+        cred = self.role.load_or_create_credentials(foreign_id)
+
+        self.assertEqual(self.role.credentials.count(), 1)
+
+        existing_cred = self.role.load_or_create_credentials(foreign_id)
+
+        self.assertEqual(existing_cred, cred)
+        self.assertEqual(self.role.credentials.count(), 1)

--- a/aleph/tests/test_role_model.py
+++ b/aleph/tests/test_role_model.py
@@ -83,10 +83,12 @@ class RoleModelTest(TestCase):
             role=self.role, source=Credential.PASSWORD)
         cred.update_secret(secret)
 
+        self.assertIsNone(cred.used_at)
         self.assertEqual(
             self.role,
             Role.authenticate_using_credential(self.role.email, secret)
         )
+        self.assertIsNotNone(cred.used_at)
 
     def test_authenticate_using_credential_bad_source(self):
         secret = self.fake.password()

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -1,0 +1,33 @@
+import json
+
+from aleph.core import db
+from aleph.tests.util import TestCase
+from aleph.tests.factories.models import RoleFactory, CredentialFactory
+
+
+class SessionsApiTestCase(TestCase):
+
+    def setUp(self):
+        super(SessionsApiTestCase, self).setUp()
+
+        self.credential = CredentialFactory.create()
+        self.role = self.credential.role
+
+    def test_password_login_get(self):
+        res = self.client.get('/api/1/sessions/login/password')
+        assert res.status_code == 404, res
+
+    def test_password_login_post_no_data(self):
+        res = self.client.post('/api/1/sessions/login/password')
+        assert res.status_code == 404, res
+
+    def test_password_login_post_good_email_and_password(self):
+        secret = self.fake.password()
+        self.credential.update_secret(secret)
+        data = dict(email=self.role.email, password=secret)
+
+        res = self.client.post('/api/1/sessions/login/password', data=data)
+
+        assert res.status_code == 200, res
+        assert res.json['role']['id'] == self.role.id, res
+        assert res.json['api_key'] == self.role.api_key, res

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -1,8 +1,6 @@
-import json
-
-from aleph.core import db
+from aleph.model import Credential
 from aleph.tests.util import TestCase
-from aleph.tests.factories.models import RoleFactory, CredentialFactory
+from aleph.tests.factories.models import CredentialFactory
 
 
 class SessionsApiTestCase(TestCase):
@@ -10,7 +8,7 @@ class SessionsApiTestCase(TestCase):
     def setUp(self):
         super(SessionsApiTestCase, self).setUp()
 
-        self.credential = CredentialFactory.create()
+        self.credential = CredentialFactory.create(source=Credential.PASSWORD)
         self.role = self.credential.role
 
     def test_password_login_get(self):

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -1,0 +1,25 @@
+from flask import Request
+
+from aleph.views.util import extract_next_url
+from aleph.tests.util import TestCase
+
+
+class ViewUtilTest(TestCase):
+
+    def setUp(self):
+        super(ViewUtilTest, self).setUp()
+
+    def test_extract_next_url_blank(self):
+        req = Request.from_values('')
+
+        self.assertEqual('/', extract_next_url(req))
+
+    def test_extract_next_url_unsafe(self):
+        req = Request.from_values('/?next={}'.format(self.fake.url()))
+
+        self.assertEqual('/', extract_next_url(req))
+
+    def test_extract_next_url_safe(self):
+        req = Request.from_values('/?next=/help')
+
+        self.assertEqual('/help', extract_next_url(req))

--- a/aleph/views/sessions_api.py
+++ b/aleph/views/sessions_api.py
@@ -11,7 +11,7 @@ from aleph.oauth import oauth
 from aleph.model import Role
 from aleph.events import log_event
 from aleph.views.cache import enable_cache
-from aleph.views.util import is_safe_url
+from aleph.views.util import extract_next_url
 
 
 log = logging.getLogger(__name__)
@@ -75,13 +75,7 @@ def login(provider=None):
         abort(404)
 
     log_event(request)
-    next_url = '/'
-    for target in request.args.get('next'), request.referrer:
-        if not target:
-            continue
-        if is_safe_url(target):
-            next_url = target
-    session['next_url'] = next_url
+    session['next_url'] = extract_next_url(request)
     callback_url = url_for('.callback', provider=provider)
     return oauth_provider.authorize(callback=callback_url)
 

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -92,3 +92,21 @@ def make_excel(result_iter, fields):
     workbook.close()
     output.seek(0)
     return output
+
+
+def extract_next_url(req):
+    """Extracts the URL/path to follow when redirects/unauthorization occurs.
+
+    :param object req: Flask request object to extract from.
+    :return: Path of the next target URL.
+    :rtype: str
+    """
+    next_url = '/'
+
+    for target in req.args.get('next'), req.referrer:
+        if not target:
+            continue
+        if is_safe_url(target):
+            next_url = target
+
+    return next_url


### PR DESCRIPTION
Split some of the existing role data into credentials model.
This layout and authentication mechanism should be flexible enough for us to pull-in additional authentication _protocols_ (LDAP is a good example, #52).

I'll prepare a separate PR for the front-end functionality.

@longhotsummer if you have a minute, it would be great to have your :eyes: on this and let us know how these changes will work for you.

@pudo from #52 I understand we want user registration to be optional?