### PR TITLE
Moar utf8

### DIFF
--- a/aleph/manage.py
+++ b/aleph/manage.py
@@ -1,7 +1,7 @@
 # coding: utf-8
 import logging
 
-from flask_script import Manager
+from flask_script import Manager, commands as flask_script_commands
 from flask_script.commands import ShowUrls
 from flask_migrate import MigrateCommand
 
@@ -21,6 +21,7 @@ from aleph.crawlers.metafolder import MetaFolderCrawler
 
 
 log = logging.getLogger('aleph')
+flask_script_commands.text_type = str
 
 app = create_app()
 mount_app_blueprints(app)

--- a/contrib/base/Dockerfile
+++ b/contrib/base/Dockerfile
@@ -31,11 +31,8 @@ RUN curl -s /tmp/pst.tgz http://www.five-ten-sg.com/libpst/packages/libpst-0.6.6
     && cd /tmp && tar xvfz pst.tgz && cd libpst-0.6.69 && ln -s /usr/bin/python /usr/bin/python2.7.10 \
     && ./configure && make && make install
 
-RUN echo "en_GB ISO-8859-1" >> /etc/locale.gen && \
-    echo "en_GB.ISO-8859-15 ISO-8859-15" >> /etc/locale.gen && \
-    echo "en_GB.UTF-8 UTF-8" >> /etc/locale.gen && \
-    echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
-    locale-gen
+RUN locale-gen 'en_GB' 'en_GB.ISO-8859-15' 'en_GB.UTF-8' 'en_US.UTF-8' 'C.UTF-8'
+ENV LANG C.UTF-8
 
 # WebKit HTML to X install since the one that comes with distros is hellishly outdated.
 RUN curl -s http://download.gna.org/wkhtmltopdf/0.12/0.12.3/wkhtmltox-0.12.3_linux-generic-amd64.tar.xz > /tmp/wkhtmltox.tar.xv \


### PR DESCRIPTION
This should fix some utf-8 issues reported in #131 

We should be able to write UTF characters in container's terminal.
There was also an issue related to `flask_script`.
It looks like it was forcing any passed arguments to call `unicode` even though the `sys.argv` escaped the strings.

/cc @pudo, @sihil