### PR TITLE
Setup fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN pip install -q --upgrade pip \
   && pip install -q -r /aleph/requirements.txt
 
 RUN pip install --pre -q -r /aleph/requirements-docs.txt
-RUN pip install -q -e . && npm --quiet --silent install .
+RUN pip install -q -e . && npm -g --quiet --silent install .
 RUN touch aleph/static/style/_custom.scss && \
     ./node_modules/webpack/bin/webpack.js --env.prod
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,9 +11,14 @@ RUN pip install -q --upgrade pip \
   && pip install -q -r /aleph/requirements.txt
 
 RUN pip install --pre -q -r /aleph/requirements-docs.txt
-RUN pip install -q -e . && npm -g --quiet --silent install .
+RUN pip install -q -e .
+
+RUN npm --quiet --silent install -g bower
+RUN echo '{ "allow_root": true }' > /root/.bowerrc
+RUN npm --quiet --silent install --prefix / .
 RUN touch aleph/static/style/_custom.scss && \
-    ./node_modules/webpack/bin/webpack.js --env.prod
+    /node_modules/webpack/bin/webpack.js --env.prod
+
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 8000

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ clear:
 assets:
 	touch aleph/static/style/_custom.scss;
 	(test -f '$(CUSTOM_SCSS_PATH)' && cp -f $(CUSTOM_SCSS_PATH) aleph/static/style/_custom.scss) || exit 0
-	./node_modules/webpack/bin/webpack.js --env.prod
+	/node_modules/webpack/bin/webpack.js --env.prod
 
 assets-dev: assets
-	./node_modules/webpack/bin/webpack.js --env.dev -w
+	/node_modules/webpack/bin/webpack.js --env.dev -w
 
 test:
 	PGPASSWORD=aleph psql -h postgres -U aleph -c 'drop database if exists aleph_test;'

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,6 @@ alembic==0.8.6
 # celery==4.0.1
 git+https://github.com/alanhamlett/celery.git@73147a9da31f2932eb4778e9474fbe72f23d21c2#egg=Celery
 
-Flask-Assets==0.10
-webassets==0.12
-cssutils==1.0.1
-
 elasticsearch==2.3.0
 psycopg2==2.6.2
 Pillow==3.2.0


### PR DESCRIPTION
This should fix #135 and partially #130 (the `node_modules` part).

Particularly the issue was caused by the fact that node installs modules inside the mountable path (`/aleph` itself). This should be fixed now.

Regarding the #135, to test it please run the command against the upstream Docker image:
```bash
docker run -t -i pudo/aleph python -c "import pkg_resources; print list(pkg_resources.iter_entry_points('aleph.ingestors'))"
```

/cc @olethanh @sihil