### PR TITLE
Credentials ui

### DIFF
--- a/aleph/model/role.py
+++ b/aleph/model/role.py
@@ -1,7 +1,6 @@
 import logging
 
 from flask import current_app
-from sqlalchemy.exc import IntegrityError
 from itsdangerous import URLSafeTimedSerializer
 from werkzeug.security import generate_password_hash, check_password_hash
 
@@ -145,7 +144,7 @@ class Role(db.Model, IdModel, SoftDeleteModel):
         :param str secret: The password to be checked.
         :rtype: bool
         """
-        return check_password_hash(self.password_digest, secret)
+        return check_password_hash(self.password_digest or '', secret)
 
     def __repr__(self):
         return '<Role(%r,%r)>' % (self.id, self.foreign_id)

--- a/aleph/static/js/aleph.js
+++ b/aleph/static/js/aleph.js
@@ -240,6 +240,11 @@ aleph.config([
     }
   });
 
+  $routeProvider.when('/signup/:code', {
+    templateUrl: 'templates/signup.html',
+    controller: 'SignupCtrl'
+  });
+
   $locationProvider.html5Mode(true);
   $compileProvider.debugInfoEnabled(false);
   cfpLoadingBarProvider.includeSpinner = false;

--- a/aleph/static/js/controllers/SignupCtrl.js
+++ b/aleph/static/js/controllers/SignupCtrl.js
@@ -1,0 +1,19 @@
+import aleph from '../aleph';
+
+aleph.controller('SignupCtrl', ['$scope', '$location', '$routeParams', 'Role',
+    function($scope, $location, $routeParams, Role) {
+
+  $scope.role = {};
+  $scope.role.code = $routeParams.code;
+  $scope.showSuccess = false;
+
+  $scope.register = function() {
+    Role.create($scope.role).then(function(role) {
+      $scope.showError = false;
+      $scope.showSuccess = true;
+    }, function(err) {
+      $scope.showError = true;
+      $scope.showSuccess = false;
+    });
+  };
+}]);

--- a/aleph/static/js/services/Role.js
+++ b/aleph/static/js/services/Role.js
@@ -29,8 +29,23 @@ aleph.factory('Role', ['$http', '$q', 'Metadata', function($http, $q, Metadata) 
     return dfd.promise;
   };
 
+  var create = function(role) {
+    var dfd = $q.defer(),
+        url = '/api/1/roles';
+
+    $http.post(url, role).then(function(res) {
+      Metadata.flush().then(function() {
+        dfd.resolve(res.data);
+      });
+    }, function(err) {
+      dfd.reject(err);
+    });
+    return dfd.promise;
+  };
+
   return {
     getAll: getAll,
-    save: save
+    save: save,
+    create: create
   };
 }]);

--- a/aleph/static/templates/signup.html
+++ b/aleph/static/templates/signup.html
@@ -1,0 +1,39 @@
+<div class="signup screen">
+  <div class="row">
+    <div class="col-md-4 col-md-offset-4">
+      <h2>
+        <i class="fa fa-fw fa-user-circle-o"></i>
+        Registration
+      </h2>
+
+      <p ng-show="showError" class="text-danger">
+        Please fill-in all the fields and make sure you are using the
+        registration link we sent you in less than 24 hours.
+      </p>
+
+      <p ng-show="showSuccess" class="text-success">
+        Your account was created. Please use the sign-in link to login.
+      </p>
+
+      <form class="form-horizontal actions" role="search" ng-submit="register()" ng-show="!showSuccess">
+        <div class="form-group">
+          <input type="text" class="form-control" autofocus
+            ng-model="role.email" placeholder="Your email...">
+        </div>
+        <div class="form-group">
+          <input type="text" class="form-control" autofocus
+            ng-model="role.name" placeholder="Your name...">
+        </div>
+        <div class="form-group">
+          <input type="password" class="form-control col-sm-3"
+            ng-model="role.password" placeholder="Your password...">
+        </div>
+        <div class="form-group text-left">
+          <button class="btn btn-primary pull-right" type="submit">Login</button>
+        </div>
+      </form>
+
+    </div>
+
+  </div>
+</div>

--- a/aleph/tests/test_roles_api.py
+++ b/aleph/tests/test_roles_api.py
@@ -139,7 +139,7 @@ class RolesApiTestCase(TestCase):
         role = Role.by_email(email).first()
         self.assertIsNotNone(role)
         self.assertTrue(role.check_password(password))
-        self.assertEqual(role.name, payload['name'])
+        self.assertEqual(role.name, payload['email'])
         self.assertEqual(role.email, payload['email'])
 
     def test_create_on_existing_email(self):

--- a/aleph/views/base_api.py
+++ b/aleph/views/base_api.py
@@ -50,6 +50,7 @@ def angular_templates():
 @blueprint.route('/collections/<path:path>')
 @blueprint.route('/tabular/<path:path>')
 @blueprint.route('/text/<path:path>')
+@blueprint.route('/signup/<path:path>')
 @blueprint.route('/')
 def ui(**kwargs):
     enable_cache(server_side=True)

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -76,7 +76,7 @@ def create():
     except:
         abort(400)
 
-    role = Role.by_email(email)
+    role = Role.by_email(email).first()
 
     if role:
         return jsonify(dict(status='ok')), 200

--- a/aleph/views/roles_api.py
+++ b/aleph/views/roles_api.py
@@ -56,6 +56,7 @@ def invite_email():
 def create():
     data = request_data()
     email = data.get('email')
+    name = data.get('name') or email
     password = data.get('password')
     signature = data.get('code')
 
@@ -75,6 +76,11 @@ def create():
     except:
         abort(400)
 
+    role = Role.by_email(email)
+
+    if role:
+        return jsonify(dict(status='ok')), 200
+
     role = Role.load_or_create(
         foreign_id='password:{}'.format(email),
         type=Role.USER,
@@ -86,7 +92,7 @@ def create():
     db.session.add(role)
     db.session.flush()
 
-    return jsonify(dict(role=role.to_dict())), 201
+    return jsonify(dict(status='ok')), 201
 
 
 @blueprint.route('/api/1/roles/<int:id>', methods=['GET'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ gunicorn==19.6.0
 Unidecode==0.04.17
 networkx==1.9.1
 XlsxWriter==0.6.6
-https://github.com/okfn/messytables/tarball/master
+messytables==0.15.2
 krauler>=0.2.2
 metafolder==0.1.2
 polyglot==16.7.4
@@ -51,7 +51,7 @@ coverage
 pyahocorasick==1.1.4
 pycrypto==2.6.1
 pylru==1.0.9
-https://github.com/mattgwwalker/msg-extractor/tarball/master
+https://github.com/mattgwwalker/msg-extractor/archive/2a24c9950d34932ed5979693cb70d758d78715df.zip#egg=extractmsg
 
 # weird pudo stuff
 countrynames>=1.1.1


### PR DESCRIPTION
This branch provides UI for password login and registration (wip). #52 (previously stas/aleph#1)

Ideally, I would merge this into the `credentials` branch after a quick review to keep the branches as small as possible for review.

General login UI (options dynamically disappear if disabled, say registration)
![screenshot from 2017-02-01 23 23 58](https://cloud.githubusercontent.com/assets/112147/22530885/c5f9f5b2-e8d5-11e6-8680-348a763228f7.png)

Email login UI
![screenshot from 2017-02-01 23 24 25](https://cloud.githubusercontent.com/assets/112147/22530896/d5b045c4-e8d5-11e6-95fb-898a8ffa288c.png)