### PR TITLE
Allow overriding celery options from config file

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -61,7 +61,6 @@ def create_app(config={}):
         Queue(WORKER_QUEUE, routing_key=WORKER_ROUTING_KEY),
         Queue(USER_QUEUE, routing_key=USER_ROUTING_KEY),
     )
-    # celery.conf.update(app.config)
     celery.conf.update(
         imports=('aleph.queues'),
         broker_url=app.config['CELERY_BROKER_URL'],
@@ -78,6 +77,7 @@ def create_app(config={}):
         worker_disable_rate_limits=True,
         beat_schedule=app.config['CELERYBEAT_SCHEDULE'],
     )
+    celery.conf.update(app.config.get('CELERY', {}))
 
     migrate.init_app(app, db, directory=app.config.get('ALEMBIC_DIR'))
     configure_oauth(app)


### PR DESCRIPTION
This also takes into account that Celery now wants its options to be lowercase, whereas the old `celery.conf.update(app.config)` gave it way too much info and tended to use uppercase.