### PR TITLE
Credentials refactoring. Flattened a bit everything.

### DIFF
--- a/aleph/core.py
+++ b/aleph/core.py
@@ -115,6 +115,10 @@ def get_app_title():
     return current_app.config.get('APP_TITLE') or get_app_name()
 
 
+def get_app_secret_key():
+    return current_app.config.get('SECRET_KEY')
+
+
 def get_es():
     app = current_app._get_current_object()
     if not hasattr(app, '_es_instance'):
@@ -178,6 +182,7 @@ archive = LocalProxy(get_archive)
 schemata = LocalProxy(get_schemata)
 datasets = LocalProxy(get_datasets)
 upload_folder = LocalProxy(get_upload_folder)
+secret_key = LocalProxy(get_app_secret_key)
 
 
 def url_for(*a, **kw):

--- a/aleph/default_settings.py
+++ b/aleph/default_settings.py
@@ -130,3 +130,6 @@ OAUTH = [{
     'access_token_url': 'https://accounts.google.com/o/oauth2/token',
     'authorize_url': 'https://accounts.google.com/o/oauth2/auth',
 }]
+
+PASSWORD_LOGIN = True
+PASSWORD_REGISTRATION = True

--- a/aleph/migrate/versions/2d230e6ce46d_added_credentials_to_roles.py
+++ b/aleph/migrate/versions/2d230e6ce46d_added_credentials_to_roles.py
@@ -1,0 +1,27 @@
+"""Added credentials to roles.
+
+Revision ID: 2d230e6ce46d
+Revises: 294b8f9f9478
+Create Date: 2017-01-26 21:42:52.722454
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = '2d230e6ce46d'
+down_revision = '294b8f9f9478'
+
+from alembic import op
+import sqlalchemy as sa
+
+
+def upgrade():
+    op.add_column('role', sa.Column('password_digest', sa.Unicode))
+    op.add_column('role', sa.Column('reset_token', sa.Unicode))
+
+    op.create_index(
+        op.f('role_reset_token'), 'role', ['reset_token'], unique=True
+    )
+
+
+def downgrade():
+    pass

--- a/aleph/model/common.py
+++ b/aleph/model/common.py
@@ -67,7 +67,7 @@ class IdModel(object):
 
 
 class UuidModel(object):
-    id = db.Column(db.String(32), primary_key=True, default=make_textid(),
+    id = db.Column(db.String(32), primary_key=True, default=make_textid,
                    nullable=False, unique=False)
 
     def to_dict(self):

--- a/aleph/notify.py
+++ b/aleph/notify.py
@@ -11,6 +11,8 @@ def notify_role(role, subject, html):
     if role.email is None:
         log.info("Role %r not have email, skip notify.", role)
         return
+    else:
+        log.info('Notify %r with:\n %r', role, html)
 
     sender = '%s <%s>' % (app_title, get_config('MAIL_FROM'))
     subject = '[%s] %s' % (app_title, subject)

--- a/aleph/static/js/controllers/AppCtrl.js
+++ b/aleph/static/js/controllers/AppCtrl.js
@@ -1,8 +1,8 @@
 import aleph from '../aleph';
 import loadMetadata from '../loaders/loadMetadata';
 
-aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll', '$httpParamSerializer', '$uibModal', 'cfpLoadingBar', 'Alert', 'Metadata',
-    function($scope, $rootScope, $location, $anchorScroll, $httpParamSerializer, $uibModal, cfpLoadingBar, Alert, Metadata) {
+aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll', '$httpParamSerializer', '$uibModal', '$http', 'cfpLoadingBar', 'Alert', 'Metadata',
+    function($scope, $rootScope, $location, $anchorScroll, $httpParamSerializer, $uibModal, $http, cfpLoadingBar, Alert, Metadata) {
 
   $scope.session = {logged_in: false};
   $scope.routeLoaded = false;
@@ -48,8 +48,35 @@ aleph.controller('AppCtrl', ['$scope', '$rootScope', '$location', '$anchorScroll
     }
   };
 
+  $rootScope.inviteEmail = function(provider) {
+    var email = $rootScope.invitationEmail;
+    var url = provider.register;
+    $http.post(url, {email: email}).then(function(res){
+      $rootScope.hideInvitationFormMsg = res.data.status;
+    });
+  };
+
+  $rootScope.emailPasswordLogin = function() {
+    var provider = $scope.session.providers.filter(
+      function(p){ return p.name == 'password'});
+
+    if(provider.length < 1) {
+      return;
+    };
+
+    var url = provider[0].login;
+    var email = $rootScope.loginEmail;
+    var password = $rootScope.loginPassword;
+
+    $http.post(url, {email: email, password: password}).then(function(res){
+      document.location.href = '/';
+    });
+  };
+
   $rootScope.triggerLogin = function() {
-    if ($scope.session.providers.length == 1) {
+    var providers = $scope.session.providers;
+
+    if (providers.length == 1 && providers[0].name != 'password') {
       var url = $httpParamSerializer({next: $location.url()});
       document.location.href = $scope.session.providers[0].login + '?' + url;
     } else {

--- a/aleph/static/templates/login.html
+++ b/aleph/static/templates/login.html
@@ -6,9 +6,62 @@
 <div class="modal-body">
   <div class="row">
     <div class="col-sm-6 col-sm-offset-3">
-      <p ng-repeat="provider in providers">
-        <a href="{{ provider.login }}?{{ next_url }}" class="btn btn-default btn-block login-{{ provider.name }}" target="_self">Sign in with {{ provider.label }}</a>
-      </p>
+      <form ng-show="showPasswordLogin" class="form-horizontal actions"
+        role="login" ng-submit="emailPasswordLogin()">
+
+        <div class="form-group">
+          <input type="text" class="form-control" autofocus
+            ng-model="$root.loginEmail" placeholder="Your email...">
+        </div>
+        <div class="form-group">
+          <input type="password" class="form-control col-sm-3"
+            ng-model="$root.loginPassword" placeholder="Your password...">
+        </div>
+        <div class="form-group text-left">
+          <a class="" ng-click="$root.showPasswordLogin = !$root.showPasswordLogin">Nevermind</a>
+          <button class="btn btn-primary pull-right" type="submit">Login</button>
+        </div>
+      </form>
+
+      <div ng-repeat="provider in providers" ng-show="!showPasswordLogin">
+        <p ng-if="provider.name != 'password'">
+          <a href="{{ provider.login }}?{{ next_url }}"
+            class="btn btn-default btn-block login-{{ provider.name }}"
+            target="_self">
+            Sign in with {{ provider.label }}
+          </a>
+        </p>
+
+        <div ng-if="provider.name == 'password' && provider.registration" >
+          <p>
+            <a ng-click="$root.showPasswordLogin = !$root.showPasswordLogin"
+              class="btn btn-default btn-block login-{{ provider.name }}">
+              Sign in with {{ provider.label }}
+            </a>
+          </p>
+
+          <p ng-show="$root.hideInvitationFormMsg" class="text-center">
+            {{$root.hideInvitationFormMsg}}
+          </p>
+
+          <form ng-if="provider.name == 'password' && !hideInvitationFormMsg"
+            class="form-horizontal actions" role="invitation"
+            ng-submit="inviteEmail(provider)"
+          >
+
+            <p class="text-center">or</p>
+
+            <div class="input-group">
+              <input type="text" class="form-control" autofocus ng-model="$root.invitationEmail"
+                placeholder="Your email...">
+              <span class="input-group-btn">
+                <button class="btn btn-primary" type="submit">Register</button>
+              </span>
+            </div>
+          </form>
+        </div>
+
+      </div>
     </div>
   </div>
 </div>

--- a/aleph/templates/email/registration_invitation.html
+++ b/aleph/templates/email/registration_invitation.html
@@ -1,0 +1,7 @@
+{% extends "email/layout.html" %}
+
+{% block content %}
+  <p>
+    To complete your registration, please visit <a href="{{url}}">our signup page</a>.
+  </p>
+{% endblock %}

--- a/aleph/tests/factories/models/__init__.py
+++ b/aleph/tests/factories/models/__init__.py
@@ -1,2 +1,3 @@
-from .collection import CollectionFactory
-from .entity import EntityFactory
+from .collection import CollectionFactory  # noqa
+from .entity import EntityFactory  # noqa
+from .role import RoleFactory  # noqa

--- a/aleph/tests/factories/models/collection.py
+++ b/aleph/tests/factories/models/collection.py
@@ -10,7 +10,7 @@ class CollectionFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = Collection
         sqlalchemy_session = db.session
 
-    foreign_id = factory.Faker('first_name')
+    foreign_id = factory.Faker('uuid4')
     label = factory.Faker('company')
     countries = factory.Sequence(
         lambda n: [factory.Faker('country_code').generate({})])

--- a/aleph/tests/factories/models/role.py
+++ b/aleph/tests/factories/models/role.py
@@ -1,0 +1,17 @@
+import factory
+
+from aleph.core import db
+from aleph.model import Role
+
+
+class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
+
+    class Meta:
+        model = Role
+        sqlalchemy_session = db.session
+
+    type = Role.USER
+    name = factory.Faker('name')
+    email = factory.Faker('email')
+    api_key = factory.Faker('uuid4')
+    foreign_id = factory.Faker('uuid4')

--- a/aleph/tests/test_models.py
+++ b/aleph/tests/test_models.py
@@ -7,9 +7,6 @@ from aleph.tests.util import TestCase
 
 class EntityModelTest(TestCase):
 
-    def tearDown(self):
-        pass
-
     def setUp(self):
         super(EntityModelTest, self).setUp()
 

--- a/aleph/tests/test_role_model.py
+++ b/aleph/tests/test_role_model.py
@@ -1,0 +1,33 @@
+from aleph.core import db
+from aleph.model import Role
+from aleph.tests.factories.models import RoleFactory
+from aleph.tests.util import TestCase
+
+
+class RoleModelTest(TestCase):
+
+    def setUp(self):
+        super(RoleModelTest, self).setUp()
+
+        self.role = RoleFactory.create()
+        db.session.commit()
+
+    def test_by_email_when_blank_email(self):
+        self.assertIsNone(Role.by_email(None))
+
+    def test_by_email_does_not_match(self):
+        self.assertIsNone(Role.by_email(self.fake.email()).first())
+
+    def test_by_email_matches(self):
+        self.assertEqual(Role.by_email(self.role.email).first(), self.role)
+
+    def test_load_or_create_role_exists(self):
+        self.assertEqual(
+            Role.load_or_create(
+                foreign_id=self.role.foreign_id,
+                type=self.role.type,
+                name=self.role.name,
+                email=self.role.email
+            ),
+            self.role
+        )

--- a/aleph/tests/test_roles_api.py
+++ b/aleph/tests/test_roles_api.py
@@ -1,6 +1,6 @@
 import json
 
-from aleph.core import db
+from aleph.model import Role
 from aleph.tests.util import TestCase
 
 
@@ -46,3 +46,92 @@ class RolesApiTestCase(TestCase):
         res = self.client.post(url, data=json.dumps(data),
                                content_type='application/json')
         assert res.status_code == 400, res
+
+    def test_invite_email_when_no_email(self):
+        res = self.client.post('/api/1/roles/invite')
+        assert res.status_code == 400, res
+
+    def test_invite_email_has_email(self):
+        res = self.client.post(
+            '/api/1/roles/invite',
+            data=dict(email=self.fake.email)
+        )
+
+        assert res.status_code == 201, res
+
+    def test_create_no_payload(self):
+        res = self.client.post('/api/1/roles')
+        assert res.status_code == 400, res
+
+    def test_create_no_email(self):
+        payload = dict(
+            email='',
+            password=self.fake.password(),
+            code=self.fake.md5()
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_no_pass(self):
+        payload = dict(
+            email=self.fake.email(),
+            password='',
+            code=self.fake.md5()
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_no_code(self):
+        payload = dict(
+            email=self.fake.email(),
+            password=self.fake.password(),
+            code=''
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_registration_disabled(self):
+        self.app.config['PASSWORD_REGISTRATION'] = False
+        email = self.fake.email()
+        payload = dict(
+            email=email,
+            password=self.fake.password(),
+            code=Role.SIGNATURE_SERIALIZER.dumps(email, salt=email)
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_short_pass(self):
+        email = self.fake.email()
+        payload = dict(
+            email=email,
+            password=self.fake.password()[:3],
+            code=Role.SIGNATURE_SERIALIZER.dumps(email, salt=email)
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_bad_code(self):
+        email = self.fake.email()
+        payload = dict(
+            email=email,
+            password=self.fake.password()[:3],
+            code=Role.SIGNATURE_SERIALIZER.dumps(email, salt='')
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+        assert res.status_code == 400, res
+
+    def test_create_success(self):
+        email = self.fake.email()
+        password = self.fake.password()
+        payload = dict(
+            email=email,
+            password=password,
+            code=Role.SIGNATURE_SERIALIZER.dumps(email, salt=email)
+        )
+        res = self.client.post('/api/1/roles', data=payload)
+
+        self.assertEqual(res.status_code, 201)
+        self.assertEqual(res.json['role']['email'], email)
+
+        self.assertTrue(Role.by_email(email).first().check_password(password))

--- a/aleph/tests/test_sessions_api.py
+++ b/aleph/tests/test_sessions_api.py
@@ -1,0 +1,52 @@
+from aleph.tests.util import TestCase
+from aleph.tests.factories.models import RoleFactory
+
+
+class SessionsApiTestCase(TestCase):
+
+    def setUp(self):
+        super(SessionsApiTestCase, self).setUp()
+
+        self.role = RoleFactory.create()
+
+    def test_status_get_with_password_registration_enabled(self):
+        res = self.client.get('/api/1/sessions')
+        assert res.status_code == 200, res
+        assert len(res.json['providers']) == 1, res
+        assert res.json['providers'][0]['name'] == 'password', res
+        assert res.json['providers'][0]['registration'] == True, res
+
+    def test_status_get_with_password_registration_disabled(self):
+        self.app.config['PASSWORD_REGISTRATION'] = False
+
+        res = self.client.get('/api/1/sessions')
+        assert res.status_code == 200, res
+        assert len(res.json['providers']) == 1, res
+        assert res.json['providers'][0]['name'] == 'password', res
+        assert res.json['providers'][0]['registration'] == False, res
+
+    def test_status_get_without_password_login(self):
+        self.app.config['PASSWORD_LOGIN'] = False
+
+        res = self.client.get('/api/1/sessions')
+        assert res.status_code == 200, res
+        assert len(res.json['providers']) == 0, res
+
+    def test_password_login_get(self):
+        res = self.client.get('/api/1/sessions/login/password')
+        assert res.status_code == 404, res
+
+    def test_password_login_post_no_data(self):
+        res = self.client.post('/api/1/sessions/login/password')
+        assert res.status_code == 404, res
+
+    def test_password_login_post_good_email_and_password(self):
+        secret = self.fake.password()
+        self.role.set_password(secret)
+        data = dict(email=self.role.email, password=secret)
+
+        res = self.client.post('/api/1/sessions/login/password', data=data)
+
+        assert res.status_code == 200, res
+        assert res.json['role']['id'] == self.role.id, res
+        assert res.json['api_key'] == self.role.api_key, res

--- a/aleph/tests/test_view_util.py
+++ b/aleph/tests/test_view_util.py
@@ -1,0 +1,25 @@
+from flask import Request
+
+from aleph.views.util import extract_next_url
+from aleph.tests.util import TestCase
+
+
+class ViewUtilTest(TestCase):
+
+    def setUp(self):
+        super(ViewUtilTest, self).setUp()
+
+    def test_extract_next_url_blank(self):
+        req = Request.from_values('')
+
+        self.assertEqual('/', extract_next_url(req))
+
+    def test_extract_next_url_unsafe(self):
+        req = Request.from_values('/?next={}'.format(self.fake.url()))
+
+        self.assertEqual('/', extract_next_url(req))
+
+    def test_extract_next_url_safe(self):
+        req = Request.from_values('/?next=/help')
+
+        self.assertEqual('/help', extract_next_url(req))

--- a/aleph/util.py
+++ b/aleph/util.py
@@ -10,6 +10,7 @@ from os import path
 from hashlib import sha1
 from tempfile import mkdtemp
 from apikit.jsonify import JSONEncoder
+from itsdangerous import TimestampSigner
 
 from aleph.text import string_value, slugify
 

--- a/aleph/views/util.py
+++ b/aleph/views/util.py
@@ -92,3 +92,21 @@ def make_excel(result_iter, fields):
     workbook.close()
     output.seek(0)
     return output
+
+
+def extract_next_url(req):
+    """Extracts the URL/path to follow when redirects/unauthorization occurs.
+
+    :param object req: Flask request object to extract from.
+    :return: Path of the next target URL.
+    :rtype: str
+    """
+    next_url = '/'
+
+    for target in req.args.get('next'), req.referrer:
+        if not target:
+            continue
+        if is_safe_url(target):
+            next_url = target
+
+    return next_url

--- a/contrib/docker_settings.py
+++ b/contrib/docker_settings.py
@@ -58,6 +58,8 @@ OAUTH = [{
     'access_token_url': 'https://accounts.google.com/o/oauth2/token',
     'authorize_url': 'https://accounts.google.com/o/oauth2/auth',
 }]
+PASSWORD_LOGIN = True
+PASSWORD_REGISTRATION = True
 
 OCR_PDF_PAGES = os.environ.get('ALEPH_PDF_OCR_IMAGE_PAGES', 'true')
 OCR_PDF_PAGES = OCR_PDF_PAGES.strip().lower() == "true"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -69,7 +69,7 @@ already landed and should make the front-end development easier.
 An LTS version of Node.js with NPM is required before we continue.
 First you will need to install the development packages (at the moment the
 build tool uses Webpack 2): `npm install .`.
-If you are using Docker, none of this is not required.
+If you are using Docker, none of this is required.
 
 In order to build the front-end you will need to run: `make assets`.
 The front-end assets are always built when you start the application.
@@ -80,6 +80,9 @@ watcher in parallel:
 ```
 docker-compose run app make assets-dev
 ```
+
+While working on the front-end development, make sure you disable browser
+cache!
 
 ## Production deployment
 


### PR DESCRIPTION
This is refactored version of #132 

I squashed a bunch of commits to make it easier to rebase. The full changelog is below:

Added role credentials.
Added tests for role and credential models.
Tests for views utils.
Added password authentication endpoint.
Config directives for password login/registration.
Added support for account creation.
Added UI for invitations and signups.

@pudo please let me know if you find this approach more relevant.
I'll rebase the #147 based on it if you're happy with it.