### PR TITLE
Guard against not have a metadata field at all

### DIFF
--- a/aleph/metadata/__init__.py
+++ b/aleph/metadata/__init__.py
@@ -70,6 +70,9 @@ class Metadata(object):
             setattr(self, field.attr, [] if field.multi else None)
 
     def has(self, name):
+        if name not in self.fields:
+            return False
+        
         value = getattr(self, self.fields[name].attr)
         if value is None:
             return False


### PR DESCRIPTION
This is useful when we've changed the metadata not to have some fields, but code still checks for them.